### PR TITLE
No re-install on every build

### DIFF
--- a/duktape.nimble
+++ b/duktape.nimble
@@ -24,7 +24,8 @@ task setup, "Download and generate":
     exec cmd & "nimgen duktape.cfg"
 
 before install:
-    setupTask()
+    if not existsDir("duktape")
+        setupTask()
 
 task test, "Test duktape":
     exec "nim c -r tests/basic_eval.nim"

--- a/duktape.nimble
+++ b/duktape.nimble
@@ -14,6 +14,7 @@ installDirs = @["duktape"]
 
 # Dependencies
 import distros
+from os import existsDir
 
 var cmd = ""
 if detectOs(Windows):

--- a/duktape.nimble
+++ b/duktape.nimble
@@ -13,8 +13,7 @@ skipDirs = @["tests","src"]
 installDirs = @["duktape"]
 
 # Dependencies
-import distros
-from os import existsDir
+import distros, os
 
 var cmd = ""
 if detectOs(Windows):
@@ -25,7 +24,7 @@ task setup, "Download and generate":
     exec cmd & "nimgen duktape.cfg"
 
 before install:
-    if not existsDir("duktape"):
+    if not dirExists("duktape"):
         setupTask()
 
 task test, "Test duktape":

--- a/duktape.nimble
+++ b/duktape.nimble
@@ -24,7 +24,7 @@ task setup, "Download and generate":
     exec cmd & "nimgen duktape.cfg"
 
 before install:
-    if not dirExists("duktape"):
+    if not dirExists("duktape/js"):
         setupTask()
 
 task test, "Test duktape":

--- a/duktape.nimble
+++ b/duktape.nimble
@@ -24,7 +24,7 @@ task setup, "Download and generate":
     exec cmd & "nimgen duktape.cfg"
 
 before install:
-    if not existsDir("duktape")
+    if not existsDir("duktape"):
         setupTask()
 
 task test, "Test duktape":


### PR DESCRIPTION
When using this repository as a requirement for a nimble package, it will re-install every time the project is built. This becomes a problem when working on a project without an internet connection.

Build log:
```
Installing https://github.com/Daedalus11069/duktape-nim@#16283c6f750fdcdf88fe1e0c69b8f3b60fc53784
Downloading https://github.com/Daedalus11069/duktape-nim using git
Copied src/js.nim to duktape/js.nim
Processing duktape/src/duk_config.h
Generating duktape/duk_config.nim
Processing duktape/src/duktape.h
Generating duktape/duktape_sys.nim
Processing duktape/duktape_sys.nim
  Verifying dependencies for duktape@0.1.0
     Info:  Dependency on nimgen@>= 0.1.4 already satisfied
  Verifying dependencies for nimgen@0.5.1
     Info:  Dependency on c2nim@>= 0.9.14 already satisfied
  Verifying dependencies for c2nim@0.9.19
     Info:  Dependency on regex@>= 0.10.0 already satisfied
  Verifying dependencies for regex@0.25.0
     Info:  Dependency on unicodedb@>= 0.7.2 already satisfied
  Verifying dependencies for unicodedb@0.12.0
 Installing duktape@0.1.0
  Warning:  A package "duktape@0.1.0" with checksum "cd18c071d221271da65651d8dde4905c69ab197c" already exists the the cache.
```

This PR fixes that by running the setup task only if the `duktape/js` directory has not been created yet.

New build log after dependency was already installed once:
```
     Info:  Dependency on https://github.com/Pasu4/duktape-nim@#3799e2bab29a120acbc1bc8008354dc52da6388a already satisfied     
  Verifying dependencies for duktape@0.1.0
     Info:  Dependency on nimgen@>= 0.1.4 already satisfied
  Verifying dependencies for nimgen@0.5.1
     Info:  Dependency on c2nim@>= 0.9.14 already satisfied
  Verifying dependencies for c2nim@0.9.19
     Info:  Dependency on regex@>= 0.10.0 already satisfied
  Verifying dependencies for regex@0.25.0
     Info:  Dependency on unicodedb@>= 0.7.2 already satisfied
  Verifying dependencies for unicodedb@0.12.0
   Building [project] using c backend
```